### PR TITLE
Fix XRA1405 issues

### DIFF
--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -216,12 +216,14 @@ static void add_async_spi_read(struct xra1405 *xra, u8 reg, int xfer_index)
     /* command byte */
     xra->tx_buf_async[xfer_index] = XRA1405_READ(reg);
     xra->spi_xfer[xfer_index * 2].tx_buf = xra->tx_buf_async + xfer_index;
+    xra->spi_xfer[xfer_index * 2].rx_buf = NULL;
     xra->spi_xfer[xfer_index * 2].len = 1;
     spi_message_add_tail(&xra->spi_xfer[xfer_index * 2], &xra->spi_msg);
 
     /* response receive buffer */
     xra->rx_buf_async[xfer_index] = 0x00;
     xra->spi_xfer[xfer_index * 2 + 1].rx_buf = xra->rx_buf_async + xfer_index;
+    xra->spi_xfer[xfer_index * 2 + 1].tx_buf = NULL;
     xra->spi_xfer[xfer_index * 2 + 1].len = 1;
     /* deselect chip select inbetween individual reads, shown on timing sheet on datasheet */
     xra->spi_xfer[xfer_index * 2 + 1].cs_change = 1;

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -634,8 +634,8 @@ static void xra1405_irq_enable(unsigned int irq)
     int pos = irq - xra->chip.base;
 
     xra->irq_soft_mask &= ~BIT(pos);
-    xra1405_async_set_cache_bit(xra, XRA1405_CACHE_IER, pos, 1);
-    xra1405_async_write_flush(xra);
+    //xra1405_async_set_cache_bit(xra, XRA1405_CACHE_IER, pos, 1);
+    //xra1405_async_write_flush(xra);
     // printk("_enable %d\n", pos);
 }
 
@@ -645,8 +645,8 @@ static void xra1405_irq_disable(unsigned int irq)
     int pos = irq - xra->chip.base;
 
     xra->irq_soft_mask |= BIT(pos);
-    xra1405_async_set_cache_bit(xra, XRA1405_CACHE_IER, pos, 0);
-    xra1405_async_write_flush(xra);
+    //xra1405_async_set_cache_bit(xra, XRA1405_CACHE_IER, pos, 0);
+    //xra1405_async_write_flush(xra);
     // printk("_disable %d\n", pos);
 }
 

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -10,7 +10,10 @@
  * The driver provides and registers functions to access the GPIOs using the
  * abstraction layer, resolving the access by itself using the SPI interface.
  * It provides function to configure the GPIOs as input or output.
- * It also supports nested interrupts if an IRQ pin was provided.
+ *
+ * It supports nested interrupts if an IRQ pin was provided.
+ * However, the irq_chip operations are blocking, thus the drivers used 
+ * on the nested irq line must not use these operation in a irq context.
  *
  * The definition of the gpio_chip  GPIO controller can be found in
  * <linux/gpio/driver.h>.

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -106,7 +106,6 @@ struct xra1405 {
     u16         irq_allocated;
     u16         irq_soft_mask;
     int         irq;
-    struct irq_domain   *irq_domain;
 
     /* Mutex for xra synchronous reading and writing */
     struct mutex        lock;

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -612,7 +612,7 @@ static void xra1405_irq_shutdown(unsigned int irq)
 }
 
 /* Optional feature to check level every check_level_interval to remedy a missed interrupt */
-static int xra1405_check_level(struct hrtimer *timer) {
+static enum hrtimer_restart xra1405_check_level(struct hrtimer *timer) {
     struct xra1405 *xra;
     struct timeval cur_time;
     ktime_t ktime_since_irq;

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -630,14 +630,12 @@ static enum hrtimer_restart xra1405_check_level(struct hrtimer* timer) {
 
     xra = container_of(timer, struct xra1405, level_check_hrtimer);
     if (xra->irq_allocated) {
-        disable_irq_nosync(xra->irq);
 
+        /* Checks if we recently had an interrupt, if so this check is probably unnecessary */
         do_gettimeofday(&cur_time);
-
-        /* check if an interrupt has made this check unnecessary */
-        if (timeval_to_ns(&cur_time) - timeval_to_ns(&xra->last_irq_time) > xra->level_check_interval_ns) {
-            /* call irq, this will re-enable the interrupt when done */
-            xra1405_irq(xra->irq, xra);
+        if (timeval_to_ns(&cur_time) - timeval_to_ns(&xra->last_irq_time) > xra->level_check_interval_ns + (1 * NSEC_PER_MSEC)) {
+            /* this should respect the IRQ is masked */
+            generic_handle_irq(xra->irq);
         }
     }
 

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -381,7 +381,7 @@ static void xra1405_isr_gsr_read_complete(void *context)
     if (xra->spi_msg.status < 0)
         goto err_data;
 
-    previous_gs = xra->cache[XRA1405_CACHE_GSR];
+    previous_gsr = xra->cache[XRA1405_CACHE_GSR];
 
 
     /* store values read from SPI read */

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -612,7 +612,7 @@ static void xra1405_irq_shutdown(unsigned int irq)
 }
 
 /* Optional feature to check level every check_level_interval to remedy a missed interrupt */
-static int xra1405_check_level(struct hrtimer timer) {
+static int xra1405_check_level(struct hrtimer *timer) {
     struct xra1405 *xra;
     struct timeval cur_time;
     ktime_t ktime_since_irq;

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -159,7 +159,7 @@ static int xra1405_write(struct xra1405 *xra, unsigned reg, unsigned val)
     xra->tx_buf_sync[0] = XRA1405_WRITE(reg);
     xra->tx_buf_sync[1] = val;
     /* Just write to the bus and don't try to read anything back */
-    return spi_write(xra->data, xra->tx_buf_sync, sizeof(xra->tx_buf_sync));
+    return spi_write(xra->data, xra->tx_buf_sync, 2);
 }
 
 static int xra1405_write16(struct xra1405 *xra, unsigned reg, u16 val)

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -615,10 +615,10 @@ static int xra1405_check_level(void *data) {
     struct xra1405 *xra = data;
 
     if (xra->irq_allocated) {
-        struct timeval time_now;
+        struct timeval cur_time;
         do_gettimeofday(&cur_time);
 
-        struct ktime_t ktime_since_irq = ktime_sub(timeval_to_ktime(xra->last_irq_time), timeval_to_ktime(cur_time));
+        ktime_t ktime_since_irq = ktime_sub(timeval_to_ktime(xra->last_irq_time), timeval_to_ktime(cur_time));
 
         /* check if an interrupt has made this check unnecessary */
         if (ktime_us_delta(ktime_since_irq, xra->level_check_interval) > 0) {
@@ -626,7 +626,7 @@ static int xra1405_check_level(void *data) {
         }
     }
 
-    hrtimer_forward(&xra->level_check_hrtimer, xra->level_check_interval);
+    hrtimer_forward_now(&xra->level_check_hrtimer, xra->level_check_interval);
     return HRTIMER_RESTART;
 }
 

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -612,10 +612,12 @@ static void xra1405_irq_shutdown(unsigned int irq)
 }
 
 /* Optional feature to check level every check_level_interval to remedy a missed interrupt */
-static int xra1405_check_level(void *data) {
-    struct xra1405 *xra = data;
+static int xra1405_check_level(struct hrtimer timer) {
+    struct xra1405 *xra;
     struct timeval cur_time;
     ktime_t ktime_since_irq;
+
+    xra = container_of(timer, struct xra1405, level_check_hrtimer);
 
     if (xra->irq_allocated) {
 
@@ -674,7 +676,6 @@ static int xra1405_irq_setup(struct xra1405 *xra)
     if (!ktime_equal(xra->level_check_interval, ktime_set(0, 0))) {
         hrtimer_init(&xra->level_check_hrtimer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
         xra->level_check_hrtimer.function = &xra1405_check_level;
-        xra->level_check_hrtimer.data = xra;
         /* start the level check timer, if this fails it means the timer was already started */
         hrtimer_start(&xra->level_check_hrtimer, xra->level_check_interval, HRTIMER_MODE_REL);
     }

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -26,8 +26,6 @@
 #include <linux/gpio.h>
 #include <linux/spi/spi.h>
 #include <linux/interrupt.h>
-//#include <linux/of_irq.h>
-//#include <linux/of_device.h>
 #include <linux/workqueue.h>
 #include <linux/delay.h>
 #include <linux/irq.h>
@@ -99,7 +97,10 @@
 #define MAKE_ALIAS(base, n) base #n
 
 struct xra1405 {
-    u16         cache[XRA1405_CACHE_COUNT]; /* Cache of the chip registers (in pairs) */
+    /* Cache of the chip registers (in pairs) */
+    u16         cache[XRA1405_CACHE_COUNT]; 
+
+    /* IRQ masks and flags */
     u16         irq_rise_mask;
     u16         irq_fall_mask;
     u16         irq_enabled_mask;

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -712,7 +712,7 @@ static int xra1405_probe_one(struct xra1405 *xra, struct device *dev,
 
     /* Disable all interrupts on input GPIOs by default */
     /* If we setup interrupts later we will configure them then */
-    status = xra1405_write16(xra, XRA1405_REG_IER, 0);
+    status = xra1405_write16(xra, XRA1405_REG_IER, 0x0000);
     if (status < 0)
         goto fail;
 

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -660,7 +660,7 @@ static int xra1405_check_level_thread(void* data) {
             ns_since_irq = timeval_to_ns(&cur_time) - timeval_to_ns(&xra->last_irq_time);
 
             /* check if an interrupt has made this check unnecessary */
-            if (ns_since_irq < ((s64) xra->level_check_interval_ms) * NSEC_PER_MSEC) {
+            if (ns_since_irq > ((s64) xra->level_check_interval_ms) * NSEC_PER_MSEC) {
                 xra1405_sync_read_isr_gsr(xra);
             }
         }
@@ -710,7 +710,7 @@ static int xra1405_irq_setup(struct xra1405 *xra)
     }
 
     if (xra->level_check_interval_ms) {
-        xra->stop_level_checking_thread = 1;
+        xra->stop_level_checking_thread = 0;
         xra->level_check_thread = kthread_run(&xra1405_check_level_thread, (void *) xra, "xra1405_level_check%d", xra->irq);
         if (IS_ERR(xra->level_check_thread)) {
              return PTR_ERR(xra->level_check_thread);
@@ -737,7 +737,7 @@ static void xra1405_irq_teardown(struct xra1405 *xra, int cleanup_irq)
      */
 
     if (cleanup_irq) {
-        xra->stop_level_checking_thread = 0;
+        xra->stop_level_checking_thread = 1;
         free_irq(xra->irq, xra);
     }
 }

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -99,16 +99,9 @@
 
 #define MAKE_ALIAS(base, n) base #n
 
-struct xra1405;
-
-struct reg_msg_context {
-    struct xra1405* xra;
-    u8 reg;
-};
-
 struct xra1405 {
     /* Cache of the chip registers (in pairs) */
-    u16         cache[XRA1405_CACHE_COUNT];
+    u16         cache[XRA1405_CACHE_COUNT]; 
 
     /* IRQ masks and flags */
     u16         irq_rise_mask;
@@ -118,7 +111,6 @@ struct xra1405 {
     u16         irq_soft_mask;
     int         irq;
 
-
     /* Mutex for xra synchronous reading and writing */
     struct mutex        lock;
 
@@ -127,16 +119,6 @@ struct xra1405 {
     /* SPI message structures */
     struct spi_message   spi_msg;
     struct spi_transfer  spi_xfer[XRA1405_READ_ASYNC_BUF_MAX * 2];
-
-    /* irq_chip masks and async spi for non-blocking */
-    u32         reg_need_write;
-    u32         reg_write_in_progress;
-    struct spi_message   async_write_spi_msgs[XRA1405_REG_COUNT];
-    struct spi_transfer  async_write_spi_xfer[XRA1405_REG_COUNT];
-    u8                   async_write_tx_buf[XRA1405_REG_COUNT * 2];
-    /* used to pass register number and xra in context of async spi callback */
-    struct reg_msg_context reg_msg_contexts[XRA1405_REG_COUNT];
-
 
     /* tx and rx buffers */
     u8                   tx_buf_async[XRA1405_READ_ASYNC_BUF_MAX];
@@ -494,81 +476,6 @@ static irqreturn_t xra1405_irq(int irq, void *data)
     return IRQ_HANDLED;
 }
 
-
-static u8 xra1405_get_cache_val8(struct xra1405* xra, u8 reg) {
-    if (reg % 2 == 0) {
-        return xra->cache[reg / 2] & 0xFF;
-    } else {
-        return (xra->cache[reg / 2] & 0xFF00) >> 8;
-    }
-}
-
-static void xra1405_async_write_flush(struct xra1405* xra);
-
-static void xra1405_async_spi_write_complete(void *context) {
-    struct reg_msg_context *reg_msg_context = context;
-    struct xra1405* xra = reg_msg_context->xra;
-    u8 write_completed_reg = reg_msg_context->reg;
-
-    xra->reg_write_in_progress &= ~BIT(write_completed_reg);
-    xra1405_async_write_flush(xra);
-}
-
-static void xra1405_send_async_spi_write8(struct xra1405 *xra, u8 reg, u8 val) {
-    struct spi_device *spi = xra->data;
-
-    spi_message_init(&xra->async_write_spi_msgs[reg]);
-
-    /* command byte (8 bits) */
-    xra->async_write_tx_buf[reg * 2] = XRA1405_WRITE(reg);
-    /* value to write (8 bits) */
-    xra->async_write_tx_buf[reg * 2 + 1] = val;
-
-    memset(&xra->async_write_spi_xfer[reg], 0, sizeof(struct spi_transfer));
-    xra->async_write_spi_xfer[reg].tx_buf = xra->async_write_tx_buf + (reg * 2);
-    xra->async_write_spi_xfer[reg].rx_buf = NULL;
-    xra->async_write_spi_xfer[reg].len = 2;
-    spi_message_add_tail(&xra->async_write_spi_xfer[reg], &xra->async_write_spi_msgs[reg]);
-
-    xra->async_write_spi_msgs[reg].context = &xra->reg_msg_contexts[reg];
-    xra->async_write_spi_msgs[reg].complete = xra1405_async_spi_write_complete;
-
-    spi_async(spi, &xra->async_write_spi_msgs[reg]);
-}
-
-static void xra1405_async_write_flush(struct xra1405* xra) {
-    int reg;
-    
-    for (reg = 0; reg < XRA1405_REG_COUNT; reg++) {
-        if (xra->reg_need_write & BIT(reg) && !(xra->reg_write_in_progress & BIT(reg))) {
-            xra->reg_write_in_progress |= BIT(reg);
-            xra->reg_need_write &= ~BIT(reg);
-            xra1405_send_async_spi_write8(xra, reg, xra1405_get_cache_val8(xra, reg));
-        }
-    }
-}
-
-static void xra1405_async_set_cache_bit(struct xra1405* xra, u8 reg, u8 offset, u8 set) {
-    /* Get the 16-bit value we have cached */
-    unsigned val = xra->cache[reg];
-
-    /* Set or unset the value in the cache as requested */
-    if (set) {
-        val |= BIT(offset);
-        xra->cache[reg] = val;
-    } else {
-        val &= ~BIT(offset);
-        xra->cache[reg] = val;
-    }
-
-    /* Mark specific register (8 bit registers) needs to be written */
-    if (offset > 7) {
-        xra->reg_need_write |= BIT(reg * 2 + 1);
-    } else {
-        xra->reg_need_write |= BIT(reg * 2);
-    }
-}
-
 static void xra1405_irq_mask(unsigned int irq)
 {
     struct xra1405 *xra = (struct xra1405*)get_irq_chip_data(irq);
@@ -636,9 +543,7 @@ static void xra1405_irq_enable(unsigned int irq)
     struct xra1405 *xra = (struct xra1405*)get_irq_chip_data(irq);
     int pos = irq - xra->chip.base;
 
-    xra->irq_soft_mask &= ~BIT(pos);
-    //xra1405_async_set_cache_bit(xra, XRA1405_CACHE_IER, pos, 1);
-    //xra1405_async_write_flush(xra);
+    __xra1405_bit(xra, XRA1405_CACHE_IER, pos, 1);
     // printk("_enable %d\n", pos);
 }
 
@@ -647,9 +552,7 @@ static void xra1405_irq_disable(unsigned int irq)
     struct xra1405 *xra = (struct xra1405*)get_irq_chip_data(irq);
     int pos = irq - xra->chip.base;
 
-    xra->irq_soft_mask |= BIT(pos);
-    //xra1405_async_set_cache_bit(xra, XRA1405_CACHE_IER, pos, 0);
-    //xra1405_async_write_flush(xra);
+    __xra1405_bit(xra, XRA1405_CACHE_IER, pos, 0);
     // printk("_disable %d\n", pos);
 }
 
@@ -814,11 +717,6 @@ static int xra1405_probe_one(struct xra1405 *xra, struct device *dev,
         names[i] = kasprintf(GFP_KERNEL, "gpio%d", i + xra->chip.base);
 
     xra->chip.names = (char **)names;
-
-    for (i = 0; i < XRA1405_REG_COUNT; i++) {
-        xra->reg_msg_contexts[i].xra = xra;
-        xra->reg_msg_contexts[i].reg = i;
-    }
 
     /* Force all GPIOs to be inputs at the beginning */
     status = xra1405_write16(xra, XRA1405_REG_GCR, 0xFFFF);

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -409,7 +409,7 @@ static void xra1405_isr_gsr_read_complete(void *context)
              * to detect the case of an interrupt happening between ISR and GSR read */
             pin_gsr = !!(xra->cache[XRA1405_CACHE_GSR] & BIT(i));
             pin_previous_gsr = !!(previous_gsr & BIT(i));
-            if (   (BIT(i) & xra->irq_fall_mask && pin_previous_gsr == 1 && pin_gsr == 0) ||
+            if (   (BIT(i) & xra->irq_fall_mask && pin_previous_gsr == 1 && pin_gsr == 0)
                 || (BIT(i) & xra->irq_rise_mask && pin_previous_gsr == 0 && pin_gsr == 1)) {
                 pin_interrupt = 1;
             }

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -396,7 +396,7 @@ static void xra1405_isr_gsr_read_complete(void *context)
 
     // printk("ISR: %04X, GSR: %04X, PREV_GSR: %04X\n",
     //                                 xra->cache[XRA1405_CACHE_ISR],
-    //                                 xra->cache[XRA1405_CACHE_GSR]);
+    //                                 xra->cache[XRA1405_CACHE_GSR],
     //                                 previous_gsr);
 
     /* Fire any nested IRQ if it is enabled */
@@ -406,7 +406,7 @@ static void xra1405_isr_gsr_read_complete(void *context)
             continue;
         }
 
-        pin_interrupt = 1
+        pin_interrupt = 1;
         if (xra->cache[XRA1405_CACHE_ISR] & BIT(i)) {
             /* This pin is enabled in interrupt state register */
             pin_interrupt = 1;

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -647,7 +647,7 @@ void xra1405_sync_read_isr_gsr(struct xra1405* xra) {
 }
 
 /*
- * \brief Optional feature to check level every check_level_interval to remedy a missed interrupt, blocking (sleeps)
+ * \brief Thread to handle level checking feature, checks if not already checked by an interrupt and runs until told to stop
  */
 static int xra1405_check_level_thread(void* data) {
     struct xra1405 *xra = data;
@@ -711,7 +711,7 @@ static int xra1405_irq_setup(struct xra1405 *xra)
 
     if (xra->level_check_interval_ms) {
         xra->stop_level_checking_thread = 1;
-        xra->level_check_thread = kthread_run(xra1405_check_level_thread, (void *) xra, "xra1405_level_check%d", xra->irq);
+        xra->level_check_thread = kthread_run(&xra1405_check_level_thread, (void *) xra, "xra1405_level_check%d", xra->irq);
         if (IS_ERR(xra->level_check_thread)) {
              return PTR_ERR(xra->level_check_thread);
         }

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -624,7 +624,7 @@ static void xra1405_irq_shutdown(unsigned int irq)
 /*
  * \brief Timer callback to handle level checking, checks if not already checked by an interrupt. Does not sleep
  */
-static int xra1405_check_level(struct hrtimer* timer) {
+static enum hrtimer_restart xra1405_check_level(struct hrtimer* timer) {
     struct xra1405 *xra;
     struct timeval cur_time;
 
@@ -637,7 +637,7 @@ static int xra1405_check_level(struct hrtimer* timer) {
         /* check if an interrupt has made this check unnecessary */
         if (timeval_to_ns(&cur_time) - timeval_to_ns(&xra->last_irq_time) > xra->level_check_interval_ns) {
             /* call irq, this will re-enable the interrupt when done */
-            xra1405_irq(xra);
+            xra1405_irq(xra->irq, xra);
         }
     }
 
@@ -711,8 +711,8 @@ static void xra1405_irq_teardown(struct xra1405 *xra, int cleanup_irq)
      */
 
     if (cleanup_irq) {
-        if (xra->level_check_interval_ns && xra->level_check_hrtimer)
-            hrtimer_stop(xra->level_check_hrtimer);
+        if (xra->level_check_interval_ns)
+            hrtimer_cancel(&xra->level_check_hrtimer);
         free_irq(xra->irq, xra);
     }
 }

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -105,7 +105,7 @@ struct reg_msg_context {
 
 struct xra1405 {
     /* Cache of the chip registers (in pairs) */
-    u16         cache[XRA1405_CACHE_COUNT]; 
+    u16         cache[XRA1405_CACHE_COUNT];
 
     /* IRQ masks and flags */
     u16         irq_rise_mask;

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -100,11 +100,11 @@
 
 struct xra1405 {
     u16         cache[XRA1405_CACHE_COUNT]; /* Cache of the chip registers (in pairs) */
-    u32         irq_rise_mask;
-    u32         irq_fall_mask;
-    u32         irq_enabled_mask;
-    u32         irq_allocated;
-    u32         irq_soft_mask;
+    u16         irq_rise_mask;
+    u16         irq_fall_mask;
+    u16         irq_enabled_mask;
+    u16         irq_allocated;
+    u16         irq_soft_mask;
     int         irq;
     struct irq_domain   *irq_domain;
 

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -376,6 +376,37 @@ static void xra1405_set(struct gpio_chip *chip, unsigned offset, int value)
     mutex_unlock(&xra->lock);
 }
 
+/*
+ * \brief Fires nested irqs using cached register values (should be set previously), does not sleep
+ */
+void xra1405_fire_nested_irqs(struct xra1405* xra) {
+    int i;
+
+    for (i = 0; i < xra->chip.ngpio; i++) {
+        /* skip if nested irq is masked (as a consequence, we only look at pins with allocated interrupts) */
+        if (xra->irq_soft_mask & BIT(i)) {
+            continue;
+        }
+
+        /* if ISR shows an interrupt, call the interrupt handler */
+        if (xra->cache[XRA1405_CACHE_ISR] & BIT(i)) {
+            generic_handle_irq(xra->chip.base + i);
+        } else {
+            /* handles where a rising or falling interrupt happens between ISR and GSR read */
+            if (xra->irq_fall_mask & BIT(i) && xra->irq_rise_mask & BIT(i)) {
+                /* we can't say anything if it's both a rising and falling edge interrupt */
+                continue;
+            } else if (xra->irq_rise_mask & BIT(i) && (xra->cache[XRA1405_CACHE_GSR] & BIT(i))) {
+                /* if we missed rising edge it will be high and not masked (by driver that allocated the interrupt) */
+                generic_handle_irq(xra->chip.base + i);
+            } else if (xra->irq_fall_mask & BIT(i) && !(xra->cache[XRA1405_CACHE_GSR] & BIT(i))) {
+                /* if we missed falling edge it will be low and not masked (by driver that allocated the interrupt) */
+                generic_handle_irq(xra->chip.base + i);
+            }
+        }
+    }
+}
+
 /**
  * \brief Stores LSB of GSR register in cache, calls nested IRQs, and reenables IRQ
  * Called by SPI read completion asynchronously (by irq handler), cannot sleep
@@ -413,36 +444,6 @@ err_data:
     enable_irq(xra->irq);
 }
 
-/*
- * \brief Fires nested irqs using cached register values (should be set previously), does not sleep
- */
-void xra1405_fire_nested_irqs(struct xra1405* xra) {
-    int i;
-
-    for (i = 0; i < xra->chip.ngpio; i++) {
-        /* skip if nested irq is masked (as a consequence, we only look at pins with allocated interrupts) */
-        if (xra->irq_soft_mask & BIT(i)) {
-            continue;
-        }
-
-        /* if ISR shows an interrupt, call the interrupt handler */
-        if (xra->cache[XRA1405_CACHE_ISR] & BIT(i)) {
-            generic_handle_irq(xra->chip.base + i);
-        } else {
-            /* handles where a rising or falling interrupt happens between ISR and GSR read */
-            if (xra->irq_fall_mask & BIT(i) && xra->irq_rise_mask & BIT(i)) {
-                /* we can't say anything if it's both a rising and falling edge interrupt */
-                continue;
-            } else if (xra->irq_rise_mask & BIT(i) && (xra->cache[XRA1405_CACHE_GSR] & BIT(i))) {
-                /* if we missed rising edge it will be high and not masked (by driver that allocated the interrupt) */
-                generic_handle_irq(xra->chip.base + i);
-            } else if (xra->irq_fall_mask & BIT(i) && !(xra->cache[XRA1405_CACHE_GSR] & BIT(i))) {
-                /* if we missed falling edge it will be low and not masked (by driver that allocated the interrupt) */
-                generic_handle_irq(xra->chip.base + i);
-            }
-        }
-    }
-}
 
 /* \brief IRQ handler
  * Masks IRQ until reenabled by ISR and GSR registers read completion & nested interrupts sent out

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -649,7 +649,7 @@ void xra1405_sync_read_isr_gsr(struct xra1405* xra) {
 /*
  * \brief Optional feature to check level every check_level_interval to remedy a missed interrupt, blocking (sleeps)
  */
-static void xra1405_check_level_thread(void* data) {
+static int xra1405_check_level_thread(void* data) {
     struct xra1405 *xra = data;
     struct timeval cur_time;
     s64 ns_since_irq;
@@ -666,6 +666,8 @@ static void xra1405_check_level_thread(void* data) {
         }
         msleep(xra->level_check_interval_ms);
     }
+
+    return 0;
 }
 
 /* Define the IRQ chip structure with the functions we have created */
@@ -709,7 +711,7 @@ static int xra1405_irq_setup(struct xra1405 *xra)
 
     if (xra->level_check_interval_ms) {
         xra->stop_level_checking_thread = 1;
-        xra->level_check_thread = kthread_run(xra1405_check_level_thread, xra, "xra1405_level_check%d", xra->irq);
+        xra->level_check_thread = kthread_run(xra1405_check_level_thread, (void *) xra, "xra1405_level_check%d", xra->irq);
         if (IS_ERR(xra->level_check_thread)) {
              return PTR_ERR(xra->level_check_thread);
         }

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -834,7 +834,7 @@ static int __devinit xra1405_probe(struct spi_device *spi)
         xra->shared_irq_time = pdata->shared_irq_time;
 
     if (pdata)
-        xra->level_check_interval = ns_to_ktime(pdata->level_check_interval_ms * 1000000);
+        xra->level_check_interval = ns_to_ktime((u64) pdata->level_check_interval_ms * 1000000ULL);
     else
         xra->level_check_interval = ktime_set(0, 0);
 

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -29,6 +29,7 @@
 //#include <linux/of_irq.h>
 //#include <linux/of_device.h>
 #include <linux/workqueue.h>
+#include <linux/hrtimer.h>
 #include <linux/ktime.h>
 #include <linux/delay.h>
 #include <linux/irq.h>

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -463,7 +463,7 @@ static irqreturn_t xra1405_irq(int irq, void *data)
     add_async_spi_read(xra, XRA1405_REG_ISR, 0);
     add_async_spi_read(xra, XRA1405_REG_ISR_MSB, 1);
     add_async_spi_read(xra, XRA1405_REG_GSR, 2);
-    add_async_spi_read(xra, XRA1405_REG_GSR_MSB, 2);
+    add_async_spi_read(xra, XRA1405_REG_GSR_MSB, 3);
 
     xra->spi_msg.complete = xra1405_isr_gsr_read_complete;
 

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -383,7 +383,6 @@ static void xra1405_set(struct gpio_chip *chip, unsigned offset, int value)
 static void xra1405_isr_gsr_read_complete(void *context)
 {
     struct xra1405 *xra = context;
-    int i = 0;
 
     if (xra->spi_msg.status < 0)
         goto err_data;
@@ -412,6 +411,37 @@ err_data:
     dev_err(xra->chip.dev,
             "Error during IRQ handler while reading the registers\n");
     enable_irq(xra->irq);
+}
+
+/*
+ * \brief Fires nested irqs using cached register values (should be set previously), does not sleep
+ */
+void xra1405_fire_nested_irqs(struct xra1405* xra) {
+    int i;
+
+    for (i = 0; i < xra->chip.ngpio; i++) {
+        /* skip if nested irq is masked (as a consequence, we only look at pins with allocated interrupts) */
+        if (xra->irq_soft_mask & BIT(i)) {
+            continue;
+        }
+
+        /* if ISR shows an interrupt, call the interrupt handler */
+        if (xra->cache[XRA1405_CACHE_ISR] & BIT(i)) {
+            generic_handle_irq(xra->chip.base + i);
+        } else {
+            /* handles where a rising or falling interrupt happens between ISR and GSR read */
+            if (xra->irq_fall_mask & BIT(i) && xra->irq_rise_mask & BIT(i)) {
+                /* we can't say anything if it's both a rising and falling edge interrupt */
+                continue;
+            } else if (xra->irq_rise_mask & BIT(i) && (xra->cache[XRA1405_CACHE_GSR] & BIT(i))) {
+                /* if we missed rising edge it will be high and not masked (by driver that allocated the interrupt) */
+                generic_handle_irq(xra->chip.base + i);
+            } else if (xra->irq_fall_mask & BIT(i) && !(xra->cache[XRA1405_CACHE_GSR] & BIT(i))) {
+                /* if we missed falling edge it will be low and not masked (by driver that allocated the interrupt) */
+                generic_handle_irq(xra->chip.base + i);
+            }
+        }
+    }
 }
 
 /* \brief IRQ handler
@@ -589,36 +619,6 @@ static void xra1405_irq_shutdown(unsigned int irq)
     mutex_unlock(&xra->lock);
 }
 
-/*
- * \brief Fires nested irqs using cached register values (should be set previously), does not sleep
- */
-void xra1405_fire_nested_irqs(struct xra1405* xra) {
-    int i;
-
-    for (i = 0; i < xra->chip.ngpio; i++) {
-        /* skip if nested irq is masked (as a consequence, we only look at pins with allocated interrupts) */
-        if (xra->irq_soft_mask & BIT(i)) {
-            continue;
-        }
-
-        /* if ISR shows an interrupt, call the interrupt handler */
-        if (xra->cache[XRA1405_CACHE_ISR] & BIT(i)) {
-            generic_handle_irq(xra->chip.base + i);
-        } else {
-            /* handles where a rising or falling interrupt happens between ISR and GSR read */
-            if (xra->irq_fall_mask & BIT(i) && xra->irq_rise_mask & BIT(i)) {
-                /* we can't say anything if it's both a rising and falling edge interrupt */
-                continue;
-            } else if (xra->irq_rise_mask & BIT(i) && (xra->cache[XRA1405_CACHE_GSR] & BIT(i))) {
-                /* if we missed rising edge it will be high and not masked (by driver that allocated the interrupt) */
-                generic_handle_irq(xra->chip.base + i);
-            } else if (xra->irq_fall_mask & BIT(i) && !(xra->cache[XRA1405_CACHE_GSR] & BIT(i))) {
-                /* if we missed falling edge it will be low and not masked (by driver that allocated the interrupt) */
-                generic_handle_irq(xra->chip.base + i);
-            }
-        }
-    }
-}
 
 
 /*
@@ -647,7 +647,6 @@ static enum hrtimer_restart xra1405_check_level(struct hrtimer *timer) {
     struct xra1405 *xra;
     struct timeval cur_time;
     ktime_t ktime_since_irq;
-    int isr, gsr;
 
     xra = container_of(timer, struct xra1405, level_check_hrtimer);
 

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -601,7 +601,7 @@ static void xra1405_irq_shutdown(unsigned int irq)
 {
     struct xra1405 *xra = (struct xra1405*)get_irq_chip_data(irq);
     unsigned int pos = irq - xra->chip.base;
-    unsigned int irq_was_allocated, input_filter;
+    unsigned int irq_was_allocated;
     int i;
 
     // printk("_shutdown %u\n", pos);
@@ -661,7 +661,7 @@ static int xra1405_irq_setup(struct xra1405 *xra)
     }
 
     err = request_irq(xra->irq, xra1405_irq,
-        IRQF_TRIGGER_FALLING | IRQF_DISABLED, XRA1405_MODULE_NAME, xra);
+        trigger | IRQF_DISABLED, XRA1405_MODULE_NAME, xra);
     if (err != 0) {
         dev_err(chip->dev, "unable to request IRQ#%d: %d\n",
                 xra->irq, err);

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -378,8 +378,8 @@ static void xra1405_isr_gsr_read_complete(void *context)
         goto err_data;
 
     /* store values read from SPI read */
-    xra->cache[XRA1405_CACHE_GSR] = xra->rx_buf_async[0];
-    xra->cache[XRA1405_CACHE_GSR] |= (xra->rx_buf_async[1] << 8);
+    xra->cache[XRA1405_CACHE_ISR] = xra->rx_buf_async[0];
+    xra->cache[XRA1405_CACHE_ISR] |= (xra->rx_buf_async[1] << 8);
 
     xra->cache[XRA1405_CACHE_GSR] = xra->rx_buf_async[2];
     xra->cache[XRA1405_CACHE_GSR] |= (xra->rx_buf_async[3] << 8);

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -10,7 +10,7 @@
  * The driver provides and registers functions to access the GPIOs using the
  * abstraction layer, resolving the access by itself using the SPI interface.
  * It provides function to configure the GPIOs as input or output.
- * It also support nested interrupts if an IRQ pin was provided.
+ * It also supports nested interrupts if an IRQ pin was provided.
  *
  * The definition of the gpio_chip  GPIO controller can be found in
  * <linux/gpio/driver.h>.
@@ -123,6 +123,19 @@ struct xra1405 {
     struct timeval *shared_irq_time;
 };
 
+static int xra1405_read(struct xra1405 *xra, unsigned reg)
+{
+    u8 tx[1];
+    int status;
+
+    /* Use the macro to compute the read command byte */
+    tx[0] = XRA1405_READ(reg);
+    /* Write 8 bits and read 8 bits synchronously */
+    status = spi_w8r8(xra->data, tx[0]);
+    /* Return the status received, either the value readed or an error */
+    return status;
+}
+
 static int xra1405_read16(struct xra1405 *xra, unsigned reg)
 {
     int lsb, msb;
@@ -135,19 +148,6 @@ static int xra1405_read16(struct xra1405 *xra, unsigned reg)
         return msb;
 
     return (lsb & 0x00FF) + ((msb & 0x00FF) << 8);
-}
-
-static int xra1405_read(struct xra1405 *xra, unsigned reg)
-{
-    u8 tx[1];
-    int status;
-
-    /* Use the macro to compute the read command byte */
-    tx[0] = XRA1405_READ(reg);
-    /* Write 8 bits and read 8 bits synchronously */
-    status = spi_w8r8(xra->data, tx[0]);
-    /* Return the status received, either the value readed or an error */
-    return status;
 }
 
 static int xra1405_write(struct xra1405 *xra, unsigned reg, unsigned val)

--- a/include/linux/spi/xra1405.h
+++ b/include/linux/spi/xra1405.h
@@ -17,11 +17,11 @@ struct xra1405_platform_data {
     struct timeval *shared_irq_time;
 
     /**
-     *  "level_based" makes the irq (if present) use level based interrupts
+     *  "irq_level_based" makes the irq (if present) use level based interrupts
      *  rather than edge based interrupts. This has no effect if no irq
      *  is provided.
      */
-    int level_based;
+     int irq_level_based;
 
     /**
      *  "irq_input_filter" sets which pins should have input filters enabled

--- a/include/linux/spi/xra1405.h
+++ b/include/linux/spi/xra1405.h
@@ -13,7 +13,7 @@ struct xra1405_platform_data {
      * "base" is the number of the first GPIO registered. The GPIO numbers
      * are sequential.
      */
-    unsigned    base;
+    unsigned int base;
     struct timeval *shared_irq_time;
     unsigned int level_check_interval_ms;
 

--- a/include/linux/spi/xra1405.h
+++ b/include/linux/spi/xra1405.h
@@ -15,6 +15,8 @@ struct xra1405_platform_data {
      */
     unsigned    base;
     struct timeval *shared_irq_time;
+    unsigned int level_check_interval_ms;
+
     /**
      * Marks the device as a interrupt controller.
      */

--- a/include/linux/spi/xra1405.h
+++ b/include/linux/spi/xra1405.h
@@ -1,42 +1,34 @@
 #ifndef XRA1405_H
 #define XRA1405_H
 
+#include <linux/types.h>
+
 struct timeval;
 struct xra1405_platform_data {
-    /**
-     * Only one chip is allowed for each chipselect. The chip provides
-     * 1 gpio_chip instance with 16 gpios.
-     */
-    // struct xra1405_chip_info    chip[1];
-
     /**
      * "base" is the number of the first GPIO registered. The GPIO numbers
      * are sequential.
      */
     unsigned int base;
+
+    /**
+     *  "shared_irq_time" is updated when an irq occures on the xra1405
+     */
     struct timeval *shared_irq_time;
 
     /**
-     * Marks the device as a interrupt controller.
+     *  "level_based" makes the irq (if present) use level based interrupts
+     *  rather than edge based interrupts. This has no effect if no irq
+     *  is provided.
      */
-    // bool    irq_controller;
+    int level_based;
 
     /**
-     * Defines which GPIOs will generate an interrupt when the status changes
+     *  "irq_input_filter" sets which pins should have input filters enabled
+     *  when a nested interrupt is used. This has no effect if no irq is
+     *  provided. Input filtering is enabled when no interrupts are used.
      */
-    // u32     irq_enabled_mask;
-
-    /**
-     * Defines which GPIOs will generate an interrupt on the rising edge
-     */
-    // u32     irq_rising_mask;
-
-    /**
-     * Defines which GPIOs will generate an interrupt on the falling edge
-     */
-    // u32     irq_falling_mask;
-
-    // u32     irq;
+    u32 irq_input_filter;
 };
 
 #endif

--- a/include/linux/spi/xra1405.h
+++ b/include/linux/spi/xra1405.h
@@ -17,11 +17,11 @@ struct xra1405_platform_data {
     struct timeval *shared_irq_time;
 
     /**
-     *  "irq_trigger_level" has the irq (if present) use level based interrupts
+     *  "irq_level_trigger" has the irq (if present) use level based interrupts
      *  rather than edge based interrupts. This has no effect if no irq
      *  is provided.
      */
-     int irq_trigger_level;
+     int irq_level_trigger;
 
     /**
      *  "irq_input_filter" sets which pins should have input filters enabled

--- a/include/linux/spi/xra1405.h
+++ b/include/linux/spi/xra1405.h
@@ -17,11 +17,11 @@ struct xra1405_platform_data {
     struct timeval *shared_irq_time;
 
     /**
-     *  "irq_level_based" makes the irq (if present) use level based interrupts
+     *  "irq_trigger_level" has the irq (if present) use level based interrupts
      *  rather than edge based interrupts. This has no effect if no irq
      *  is provided.
      */
-     int irq_level_based;
+     int irq_trigger_level;
 
     /**
      *  "irq_input_filter" sets which pins should have input filters enabled

--- a/include/linux/spi/xra1405.h
+++ b/include/linux/spi/xra1405.h
@@ -15,7 +15,6 @@ struct xra1405_platform_data {
      */
     unsigned int base;
     struct timeval *shared_irq_time;
-    unsigned int level_check_interval_ms;
 
     /**
      * Marks the device as a interrupt controller.

--- a/include/linux/spi/xra1405.h
+++ b/include/linux/spi/xra1405.h
@@ -28,7 +28,7 @@ struct xra1405_platform_data {
      *  when a nested interrupt is used. This has no effect if no irq is
      *  provided. Input filtering is enabled when no interrupts are used.
      */
-    u32 irq_input_filter;
+    u16 irq_input_filter;
 };
 
 #endif


### PR DESCRIPTION
Issues with the XRA1405 GPIO expander driver:
- It uses level interrupts to detect the xra1405 interrupt, but this can be an issue if we are chaining the irq line and it doesn't support level interrupts. It also and causes interrupts to be spammed if we can't clear the interrupt.
- Reading multiple registers in a single SPI read command is not possible on this device (tested). This is done in the interrupt handler to read the GSR (GPIO State Register) and will result in the Most Significant Byte of the GSR not getting read. This is also done in the unused function xra1405_read16.
- If a rising or falling edge interrupt occurs in between the ISR and GSR async reads, it would be missed. They are also separate SPI messages, so if the bus is busy they could be done arbitrarily far apart. 
- The SPI tx and rx buffers are not DMA-safe, they are statically allocated or on the stack. SPI requires they be DMA-safe... This works as our board's SPI driver only does DMA on 16 bytes or greater, but if we switch to a board that uses a DMA with a lower min for SPI it will break.
- The xra1405_probe_one function has double writes of the FEIR register, unnecessary initial writes, and inconsistent comments
- If nested interrupts are used then stop being used, input filtering will be disabled. As well, on nested interrupts we always have input filtering off, but this may be desired.
- irq_chip operations (for nested interrupts) are blocking, but need to be non-blocking for many downstream drivers. This is not fixed in this pull request.
- Inconsistent comments and unused variables/code from development

The fixes in this pull request:
- Change from level to falling edge interrupts by default and add a platform data option for this.
- Added platform data option to enable input filtering on nested irq pins and fixed input filtering getting disabled when enabling and disabling interrupts.
- The interrupt handler now does reads each byte register with its own command. The read16 function has been fixed, it is still unused but could be helpful for debugging or future changes.
- I removed the possibility of a rising or falling interrupt occurring between ISR and GSR by checking the GSR if the ISR bit is not set and calling the interrupt if the GPIO is active (1 on rising, 0 on falling). When this is active from a previous interrupt, it is expected to be masked by the driver that allocated the interrupt, so that is not our problem.
- I have put the ISR and GSR into the same SPI message with cs_change to toggle CS in-between reads (this is necessary). This cleans up the code a lot and reduces the chance of an interrupt between ISR and GSR reads.
- I cleaned up the writes a bit by looking at the datasheet and existing writes elsewhere in the driver. This has little practical impact, but makes the code more understandable.
- I put both sync tx and rx buffers in the xra data structure so they are on the heap (with kalloc under page size it should be DMA-safe) and replaced usage of tx and rx stack buffers throughout
- Added warning about irq_chip blocking
- Cleanup throughout

A few notes:
- I attempted to implement an option to check for missed interrupts every x ms, but failed as the difficultly of implementing it safely was more than expected.
- I attempted to make irq_chip operations non-blocking to allow for certain downstream driver, but I was not able to implement it due to limitations of the current kernel version. Fixing this may require updated to a slightly newer kernel version or implementing this patch https://lkml.iu.edu/0908.1/02870.html to get irq_bus_sync_unlock and irq_bus_lock. 
- A one chained xra1405 irq line on another xra1405s could be handled by setting up an interrupt on that chained irq on the first xra1405, and then fully handling the reading of the interrupts of the chained xra1405 in user space (not allocating any nested irqs on the chained xra1405).


REVIEWED BY: Owen, Rafael, Lorenzo, Josh, and Blake

Datasheet:
[xra1405.pdf](https://github.com/user-attachments/files/19479797/xra1405.pdf)

SPI:
[spi-header](https://github.com/PolySat/linux-2.6.30.2/blob/master/include/linux/spi/spi.h)
[spi-summary](https://github.com/PolySat/linux-2.6.30.2/blob/master/Documentation/spi/spi-summary)

DMA:
[documentation](https://github.com/PolySat/linux-2.6.30.2/blob/master/Documentation/DMA-mapping.txt)
[basic howto](https://docs.kernel.org/core-api/dma-api.html)

