### PR TITLE
Add internal pullups for xra1405 and revert nested interrupt

### DIFF
--- a/arch/arm/mach-at91/board-polysat1.c
+++ b/arch/arm/mach-at91/board-polysat1.c
@@ -396,7 +396,11 @@ static struct {
 } plat_data_axsem = { AT91_PIN_PC8, AT91_PIN_PC10, AT91_PIN_PB19 };
 
 static struct timeval xra_shared_irq_time;
-static struct xra1405_platform_data plat_data_xra1405 = { 160, &xra_shared_irq_time };
+static struct xra1405_platform_data plat_data_xra1405 = {
+        .base = 160,
+        .shared_irq_time = &xra_shared_irq_time,
+        .internal_pullups = 0xEE00 /* pullups on 6 floating pins 1110 1110 0000 0000 */
+};
 static struct DS3234PlatData plat_data_ds3234 = { 168, &xra_shared_irq_time };
 
 /*

--- a/drivers/gpio/xra1405.c
+++ b/drivers/gpio/xra1405.c
@@ -115,6 +115,9 @@ struct xra1405 {
     u16         irq_input_filter;
     int         irq_level_trigger;
 
+    /* Pull-up platform data option */
+    u16		internal_pullups;
+
     /* Mutex for xra synchronous reading and writing */
     struct mutex        lock;
 
@@ -717,7 +720,7 @@ static int xra1405_probe_one(struct xra1405 *xra, struct device *dev,
         goto fail;
 
     /* Force all pull-ups to be disabled */
-    status = xra1405_write16(xra, XRA1405_REG_PUR, 0x0000);
+    status = xra1405_write16(xra, XRA1405_REG_PUR, xra->internal_pullups);
     if (status < 0)
         goto fail;
 
@@ -800,6 +803,7 @@ static int __devinit xra1405_probe(struct spi_device *spi)
         xra->shared_irq_time = pdata->shared_irq_time;
         xra->irq_level_trigger = pdata->irq_level_trigger;
         xra->irq_input_filter = pdata->irq_input_filter;
+	xra->internal_pullups = pdata->internal_pullups;
     }
 
     /* Register the number of GPIO the chip has */

--- a/include/linux/spi/xra1405.h
+++ b/include/linux/spi/xra1405.h
@@ -29,6 +29,11 @@ struct xra1405_platform_data {
      *  provided. Input filtering is enabled when no interrupts are used.
      */
     u16 irq_input_filter;
+
+    /**
+     * "internal_pullups" sets which pins should have internal pull-ups enabled
+     */
+    u16 internal_pullups;
 };
 
 #endif


### PR DESCRIPTION
From Clksync Kernel Panic Report document:

Floating inputs on the xra1405 caused unexpected interrupts. The XRA1405 race condition GPIO fix caused nested RTC interrupts to be called by these unexpected interrupts. These unexpected RTC PPS interrupts caused the RTC DS3234 driver to access non-existence memory `Unable to handle kernel paging request at virtual address`. We confirmed this by driving the floating pin that was causing the issue at the time causing this interrupt to ground and confirming the issue went away. 

The fixes are to be done to the xra1405 driver and polysat board kernel file.

- The first fix, the ISR-GSR interrupt miss change in the SPI interrupt-context callback and should be removed. 
	- This change tried to solve: missing an interrupt exists when there are multiple downstream IRQs, and one triggers while another interrupt has its ISR (Interrupt Status Register) has been read but not the GSR (GPIO State Register).
	- The change relied on downstream drivers masking their interrupts, which they often do not. The chance and impact of missing an interrupt is not high for CP16, and only effects clksync and PIB. 
	- Removing this change should fix the kernel panic as the RTC will not encounter unexpected interrupts. However it reintroduced this missed interrupt issue
- The second fix is to resolve the consequences of the first fix. This requires adding a configuration to xra1405 for adding pull-ups to specific pins to remove the floating state of the floating inputs.
	- The xra1405 should have this put in its platform data
	- The platform data should be set in linux-2.6.30.2/arch/arm/mach-at91/board-polysat1.c to put pull-ups on the floating pins
	- The PIB driver should be modified to use pull-ups on the floating pins